### PR TITLE
fix: Don't crash when highlighting JS 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,21 +135,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bit-set"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
-dependencies = [
- "bit-vec",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -490,16 +475,6 @@ checksum = "4c2b6b5a29c02cdc822728b7d7b8ae1bab3e3b05d44522770ddd49722eeac7eb"
 dependencies = [
  "indenter",
  "once_cell",
-]
-
-[[package]]
-name = "fancy-regex"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6b8560a05112eb52f04b00e5d3790c0dd75d9d980eb8a122fb23b92a623ccf"
-dependencies = [
- "bit-set",
- "regex",
 ]
 
 [[package]]
@@ -911,6 +886,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
+name = "onig"
+version = "6.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c4b31c8722ad9171c6d77d3557db078cab2bd50afcc9d09c8b315c59df8ca4f"
+dependencies = [
+ "bitflags",
+ "libc",
+ "once_cell",
+ "onig_sys",
+]
+
+[[package]]
+name = "onig_sys"
+version = "69.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b829e3d7e9cc74c7e315ee8edb185bf4190da5acde74afd7fc59c35b1f086e7"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "os_info"
 version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1286,11 +1283,11 @@ checksum = "c6c454c27d9d7d9a84c7803aaa3c50cd088d2906fe3c6e42da3209aa623576a8"
 dependencies = [
  "bincode",
  "bitflags",
- "fancy-regex",
  "flate2",
  "fnv",
  "lazy_static",
  "once_cell",
+ "onig",
  "regex-syntax",
  "serde",
  "serde_derive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,6 +165,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d4260bcc2e8fc9df1eac4919a720effeb63a3f0952f5bf4944adfa18897f09"
+dependencies = [
+ "memchr",
+ "once_cell",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "bugreport"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -291,6 +303,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -325,6 +343,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
 dependencies = [
  "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_more"
+version = "0.99.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
  "syn",
 ]
 
@@ -452,6 +483,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "eyre"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c2b6b5a29c02cdc822728b7d7b8ae1bab3e3b05d44522770ddd49722eeac7eb"
+dependencies = [
+ "indenter",
+ "once_cell",
+]
+
+[[package]]
 name = "fancy-regex"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -564,7 +605,8 @@ dependencies = [
  "env_logger",
  "flate2",
  "git-config-env",
- "git2",
+ "git-fixture",
+ "git2 0.15.0",
  "human-panic",
  "is-terminal",
  "log",
@@ -577,6 +619,19 @@ dependencies = [
  "term-transcript",
  "terminal_size",
  "textwrap",
+]
+
+[[package]]
+name = "git-fixture"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "001007c03f749abb9a79f52caf80d2f77da3b56a188872ea55bb05beb49774eb"
+dependencies = [
+ "bstr",
+ "derive_more",
+ "eyre",
+ "git2 0.16.1",
+ "log",
 ]
 
 [[package]]
@@ -606,6 +661,19 @@ name = "git2"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2994bee4a3a6a51eb90c218523be382fd7ea09b16380b9312e9dbe955ff7c7d1"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
+]
+
+[[package]]
+name = "git2"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf7f68c2995f392c49fffb4f95ae2c873297830eb25c6bc4c114ce8f4562acc"
 dependencies = [
  "bitflags",
  "libc",
@@ -683,6 +751,12 @@ dependencies = [
  "unicode-bidi",
  "unicode-normalization",
 ]
+
+[[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
@@ -763,9 +837,9 @@ checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.14.0+1.5.0"
+version = "0.14.2+1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47a00859c70c8a4f7218e6d1cc32875c4b55f6799445b842b0d8ed5e4c3d959b"
+checksum = "7f3d95f6b51075fe9810a7ae22c7095f12b98005ab364d8544797a825ce946a4"
 dependencies = [
  "cc",
  "libc",
@@ -1024,6 +1098,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1034,6 +1114,15 @@ name = "rustc-demangle"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -1063,6 +1152,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ bugreport = "0.5.0"
 dunce = "1.0.3"
 
 [dev-dependencies]
+git-fixture = "0.3.1"
 snapbox = { version = "0.4.10", features = ["path"] }
 term-transcript = "0.2.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ concolor-clap = { version = "0.1.0", features = ["api"] }
 proc-exit = "2.0.1"
 human-panic = "1.1.3"
 anyhow = "1.0.68"
-syntect = { version = "5.0.0", default-features = false, features = ["parsing", "regex-fancy"] }
+syntect = { version = "5.0.0", default-features = false, features = ["parsing", "regex-onig"] }
 terminal_size = "0.2.3"
 textwrap = "0.16.0"
 anstyle = "0.3.1"

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,0 +1,37 @@
+#[test]
+fn basic() {
+    let root = snapbox::path::PathFixture::mutable_temp().unwrap();
+    let root_path = root.path().unwrap();
+    let plan = git_fixture::TodoList {
+        commands: vec![
+            git_fixture::Command::Tree(git_fixture::Tree {
+                files: [("basic.js", "test('arg1');")]
+                    .into_iter()
+                    .map(|(p, c)| (p.into(), c.into()))
+                    .collect::<std::collections::HashMap<_, _>>(),
+                message: Some("A".to_owned()),
+                author: None,
+            }),
+            git_fixture::Command::Branch("main".into()),
+        ],
+        ..Default::default()
+    };
+    plan.run(root_path).unwrap();
+
+    snapbox::cmd::Command::new(snapbox::cmd::cargo_bin!("git-dive"))
+        .arg("basic.js")
+        .current_dir(root_path)
+        .assert()
+        .success()
+        .stdout_eq(
+            "\
+HEAD 1 │ test('arg1');
+",
+        )
+        .stderr_matches(
+            "\
+",
+        );
+
+    root.close().unwrap();
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -61,15 +61,9 @@ fn js_highlight_panics() {
         .current_dir(root_path)
         .env("CLICOLOR_FORCE", "1")
         .assert()
-        .failure()
-        .stdout_eq(
-            "\
-",
-        )
+        .success()
         .stderr_matches(
             "\
-thread 'main' panicked at 'regex string should be pre-tested: [..]
-note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 ",
         );
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -35,3 +35,43 @@ HEAD 1 │ test('arg1');
 
     root.close().unwrap();
 }
+
+#[test]
+fn js_highlight_panics() {
+    let root = snapbox::path::PathFixture::mutable_temp().unwrap();
+    let root_path = root.path().unwrap();
+    let plan = git_fixture::TodoList {
+        commands: vec![
+            git_fixture::Command::Tree(git_fixture::Tree {
+                files: [("basic.js", "test('arg1');")]
+                    .into_iter()
+                    .map(|(p, c)| (p.into(), c.into()))
+                    .collect::<std::collections::HashMap<_, _>>(),
+                message: Some("A".to_owned()),
+                author: None,
+            }),
+            git_fixture::Command::Branch("main".into()),
+        ],
+        ..Default::default()
+    };
+    plan.run(root_path).unwrap();
+
+    snapbox::cmd::Command::new(snapbox::cmd::cargo_bin!("git-dive"))
+        .arg("basic.js")
+        .current_dir(root_path)
+        .env("CLICOLOR_FORCE", "1")
+        .assert()
+        .failure()
+        .stdout_eq(
+            "\
+",
+        )
+        .stderr_matches(
+            "\
+thread 'main' panicked at 'regex string should be pre-tested: [..]
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+",
+        );
+
+    root.close().unwrap();
+}


### PR DESCRIPTION
It appears that the `regex-fancy` engine fall down flat here and we need
to use `regex-onig`, which is what `bat` uses.

Fixes #71